### PR TITLE
Less seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,6 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-1000.times do
+100.times do
   Location.create({city: Faker::Address.city})
 end


### PR DESCRIPTION
1000 seed data will crash most PCs when searching a single letter. Reduced to 100.